### PR TITLE
Isha | Test | Fixed multi tab issue

### DIFF
--- a/src/app/[company]/[country]/account-statement/page.tsx
+++ b/src/app/[company]/[country]/account-statement/page.tsx
@@ -7,7 +7,6 @@ import { selectCompanyUniqueName, selectAccountUniqueName } from "@/store/slices
 import {
   getAccountStatement,
   downloadAccountStatement,
-  formatCurrency,
   convertDateToAPIFormat,
   AccountStatementRequest,
   Transaction,
@@ -15,6 +14,7 @@ import {
   AccountAddress,
   Address,
 } from "@/utils/accountStatement";
+import { formatCurrencyAmount } from "@/utils/currency";
 import { base64ToBlob } from "@/utils/invoicePreview";
 import { DataTable } from "@/components/DataTable";
 import { Dropdown } from "@/components/Dropdown";
@@ -29,6 +29,7 @@ import { LEDGER_TYPE_CREDIT, LEDGER_TYPE_DEBIT } from "@/constants/ledger";
 import { FileType, EXPORT_FILE_CONFIG, PAGINATION_LIMIT } from "@/constants";
 import { SortOrder } from "@/constants/sort";
 import { useToast } from "@/contexts/ToastContext";
+import { getCompanyAndAccountNames } from "@/utils/getUserDataFromStorage";
 
 export default function AccountStatementPage() {
   const params = useParams();
@@ -60,34 +61,15 @@ export default function AccountStatementPage() {
   const [sortDirection, setSortDirection] = useState<SortOrder>(SortOrder.ASC);
   const { showToast } = useToast();
 
-  const getCompanyAndAccountNames = () => {
-    let companyUniqueName = companyUniqueNameFromRedux;
-    let accountUniqueName = accountUniqueNameFromRedux;
-
-    if (!companyUniqueName || !accountUniqueName) {
-      if (typeof window !== "undefined") {
-        const userData = localStorage.getItem("userData");
-        if (userData) {
-          try {
-            const parsedData = JSON.parse(userData);
-            companyUniqueName = companyUniqueName || parsedData.companyUniqueName;
-            accountUniqueName = accountUniqueName || parsedData.account?.uniqueName;
-          } catch (e) {
-            console.error("Error parsing userData:", e);
-          }
-        }
-      }
-    }
-
-    return { companyUniqueName, accountUniqueName };
-  };
+  const resolveCompanyAndAccount = () =>
+    getCompanyAndAccountNames(companyName, companyUniqueNameFromRedux, accountUniqueNameFromRedux);
 
   useEffect(() => {
     fetchAccountStatement();
   }, [fromDate, toDate, currentPage, itemsPerPage, sortDirection]);
 
   const fetchAccountStatement = async () => {
-    const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames();
+    const { companyUniqueName, accountUniqueName } = resolveCompanyAndAccount();
     if (!companyUniqueName || !accountUniqueName) {
       setError("Missing company or account information");
       setLoading(false);
@@ -135,7 +117,7 @@ export default function AccountStatementPage() {
   };
 
   const handleExport = async (format: FileType) => {
-    const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames();
+    const { companyUniqueName, accountUniqueName } = resolveCompanyAndAccount();
     if (!companyUniqueName || !accountUniqueName) return;
 
     setIsExporting(true);
@@ -261,7 +243,7 @@ export default function AccountStatementPage() {
         header: "Amount",
         accessor: (row: Transaction) =>
           row.voucherAmount.type === LEDGER_TYPE_DEBIT
-            ? formatCurrency(row.voucherAmount.amount, accountAddress?.currency?.symbol)
+            ? formatCurrencyAmount(row.voucherAmount.amount, accountAddress?.currency)
             : "",
         headerClassName: "text-right",
         cellClassName: "text-right",
@@ -270,7 +252,7 @@ export default function AccountStatementPage() {
         header: "Payments",
         accessor: (row: Transaction) =>
           row.voucherAmount.type === LEDGER_TYPE_CREDIT
-            ? formatCurrency(row.voucherAmount.amount, accountAddress?.currency?.symbol)
+            ? formatCurrencyAmount(row.voucherAmount.amount, accountAddress?.currency)
             : "",
         headerClassName: "hidden md:table-cell text-right",
         cellClassName: "hidden md:table-cell text-right",
@@ -278,12 +260,12 @@ export default function AccountStatementPage() {
       {
         header: "Balance",
         accessor: (row: Transaction) =>
-          formatCurrency(row.closingBalance.amount, accountAddress?.currency?.symbol),
+          formatCurrencyAmount(row.closingBalance.amount, accountAddress?.currency),
         headerClassName: "text-right",
         cellClassName: "text-right font-medium",
       },
     ],
-    [accountAddress?.currency?.symbol, sortDirection]
+    [accountAddress?.currency, sortDirection]
   );
 
   return (
@@ -368,34 +350,31 @@ export default function AccountStatementPage() {
                           <div className="flex justify-between text-gray-900">
                             <span>Opening Balance</span>
                             <span className="font-medium">
-                              {formatCurrency(
+                              {formatCurrencyAmount(
                                 summary.openingBalance.amount,
-                                accountAddress?.currency?.symbol
+                                accountAddress?.currency
                               )}
                             </span>
                           </div>
                           <div className="flex justify-between text-gray-900">
                             <span>Invoiced Amount</span>
                             <span className="font-medium">
-                              {formatCurrency(summary.debitTotal, accountAddress?.currency?.symbol)}
+                              {formatCurrencyAmount(summary.debitTotal, accountAddress?.currency)}
                             </span>
                           </div>
                           <div className="flex justify-between text-gray-900">
                             <span>Amount Paid</span>
                             <span className="font-medium">
-                              {formatCurrency(
-                                summary.creditTotal,
-                                accountAddress?.currency?.symbol
-                              )}
+                              {formatCurrencyAmount(summary.creditTotal, accountAddress?.currency)}
                             </span>
                           </div>
                           <div className="border-t-2 border-gray-400 pt-2" />
                           <div className="flex justify-between font-semibold text-gray-800">
                             <span>Balance Due</span>
                             <span>
-                              {formatCurrency(
+                              {formatCurrencyAmount(
                                 summary.closingBalance.amount,
-                                accountAddress?.currency?.symbol
+                                accountAddress?.currency
                               )}
                             </span>
                           </div>

--- a/src/app/[company]/[country]/invoice-pay/account/[accountUniqueName]/voucher/[voucherUniqueName]/page.tsx
+++ b/src/app/[company]/[country]/invoice-pay/account/[accountUniqueName]/voucher/[voucherUniqueName]/page.tsx
@@ -106,8 +106,8 @@ export default function InvoicePayPage() {
   const isRefetchingAfterPaymentRef = useRef(false);
 
   const getNames = useCallback(() => {
-    return getStorageNames(companyUniqueNameFromRedux, accountUniqueNameFromRedux);
-  }, [companyUniqueNameFromRedux, accountUniqueNameFromRedux]);
+    return getStorageNames(companyName, companyUniqueNameFromRedux, accountUniqueNameFromRedux);
+  }, [companyName, companyUniqueNameFromRedux, accountUniqueNameFromRedux]);
 
   const accountUniqueName = accountUniqueNameParam || getNames().accountUniqueName;
   const companyUniqueName = searchParams.get("companyUniqueName") || getNames().companyUniqueName;

--- a/src/app/[company]/[country]/invoice-pay/account/[accountUniqueName]/voucher/[voucherUniqueName]/page.tsx
+++ b/src/app/[company]/[country]/invoice-pay/account/[accountUniqueName]/voucher/[voucherUniqueName]/page.tsx
@@ -131,6 +131,7 @@ export default function InvoicePayPage() {
         if (!el) return;
         (window as unknown as { initVerification?: (opts: unknown) => void }).initVerification?.({
           referenceId,
+          theme: "light",
           success: () => {},
           failure: (err: unknown) => console.error("[InvoicePay Auth] Login failed:", err),
         });

--- a/src/app/[company]/[country]/invoice/page.tsx
+++ b/src/app/[company]/[country]/invoice/page.tsx
@@ -77,6 +77,7 @@ export default function InvoicesPage() {
 
   useEffect(() => {
     const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+      companyName,
       companyUniqueNameFromRedux,
       accountUniqueNameFromRedux
     );
@@ -109,6 +110,7 @@ export default function InvoicesPage() {
 
   const handleInvoiceClick = (invoiceUniqueName: string) => {
     const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+      companyName,
       companyUniqueNameFromRedux,
       accountUniqueNameFromRedux
     );
@@ -123,6 +125,7 @@ export default function InvoicesPage() {
   const navigateToInvoicePay = useCallback(
     (invoiceUniqueName: string) => {
       const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+        companyName,
         companyUniqueNameFromRedux,
         accountUniqueNameFromRedux
       );
@@ -150,6 +153,7 @@ export default function InvoicesPage() {
     e.stopPropagation();
 
     const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+      companyName,
       companyUniqueNameFromRedux,
       accountUniqueNameFromRedux
     );
@@ -213,6 +217,7 @@ export default function InvoicesPage() {
     balanceStatusOverride?: string[]
   ) => {
     const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+      companyName,
       companyUniqueNameFromRedux,
       accountUniqueNameFromRedux
     );
@@ -237,6 +242,7 @@ export default function InvoicesPage() {
 
   const refetchInvoicesWithStatus = (newStatusFilter: StatusFilterValue) => {
     const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+      companyName,
       companyUniqueNameFromRedux,
       accountUniqueNameFromRedux
     );
@@ -276,21 +282,11 @@ export default function InvoicesPage() {
     statusFilter !== "All Invoices" || sortBy !== "Date" || sortDirection !== SortOrder.DESC;
 
   const handleDownloadInvoice = async (invoiceUniqueName: string, invoiceNumber: string) => {
-    let companyUniqueName = companyUniqueNameFromRedux;
-    let accountUniqueName = accountUniqueNameFromRedux;
-
-    if (!companyUniqueName && typeof window !== "undefined") {
-      const userData = localStorage.getItem("userData");
-      if (userData) {
-        try {
-          const parsedData = JSON.parse(userData);
-          companyUniqueName = parsedData.companyUniqueName;
-          accountUniqueName = parsedData.account?.uniqueName;
-        } catch (e) {
-          console.error("Error parsing userData:", e);
-        }
-      }
-    }
+    const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+      companyName,
+      companyUniqueNameFromRedux,
+      accountUniqueNameFromRedux
+    );
 
     if (!companyUniqueName || !accountUniqueName) {
       console.error("Missing company or account unique name");

--- a/src/app/[company]/[country]/invoice/preview/page.tsx
+++ b/src/app/[company]/[country]/invoice/preview/page.tsx
@@ -97,6 +97,7 @@ export default function InvoicePreviewPage() {
         if (!authContainerElement) return;
         (window as any).initVerification?.({
           referenceId,
+          theme: "light",
           success: () => console.log("[Preview Auth] Login initialized successfully"),
           failure: (err: unknown) => console.error("[Preview Auth] Login failed:", err),
         });

--- a/src/app/[company]/[country]/invoice/preview/page.tsx
+++ b/src/app/[company]/[country]/invoice/preview/page.tsx
@@ -22,6 +22,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { DEFAULT_CONFIG } from "@/config/default";
 import { getSessionCookie } from "@/utils/cookies";
+import { getUserDataFromStorage } from "@/utils/getUserDataFromStorage";
 import { useToast } from "@/contexts/ToastContext";
 import { formatCurrencyAmount } from "@/utils/currency";
 
@@ -132,15 +133,10 @@ export default function InvoicePreviewPage() {
     let accountUniqueName = accountUniqueNameFromRedux;
 
     if ((!companyUniqueName || !accountUniqueName) && typeof window !== "undefined") {
-      const stored = localStorage.getItem("userData");
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored);
-          companyUniqueName ||= parsed.companyUniqueName;
-          accountUniqueName ||= parsed.account?.uniqueName;
-        } catch {
-          // Skip invalid userData; continue with Redux or URL params
-        }
+      const parsed = getUserDataFromStorage(companyName);
+      if (parsed) {
+        companyUniqueName = companyUniqueName ?? parsed.companyUniqueName ?? null;
+        accountUniqueName = accountUniqueName ?? parsed.account?.uniqueName ?? null;
       }
     }
 

--- a/src/app/[company]/[country]/layout.tsx
+++ b/src/app/[company]/[country]/layout.tsx
@@ -19,6 +19,7 @@ import { Footer } from "@/components/Footer";
 import SessionGuard from "@/components/SessionGuard";
 import { mergeClassNames } from "@/lib/utils";
 import { getSessionCookie } from "@/utils/cookies";
+import { getUserDataFromStorage } from "@/utils/getUserDataFromStorage";
 
 function LayoutContent({ children }: { children: React.ReactNode }) {
   const { isCollapsed } = useSidebar();
@@ -95,15 +96,10 @@ export default function CompanyLayout({ children }: { children: React.ReactNode 
     let accountUniqueName = accountUniqueNameFromRedux;
 
     if (!companyUniqueName) {
-      const userData = localStorage.getItem("userData");
-      if (userData) {
-        try {
-          const parsedData = JSON.parse(userData);
-          companyUniqueName = parsedData.companyUniqueName;
-          accountUniqueName = parsedData.account?.uniqueName ?? accountUniqueName;
-        } catch (e) {
-          console.error("Error parsing userData:", e);
-        }
+      const parsedData = getUserDataFromStorage(companyName);
+      if (parsedData) {
+        companyUniqueName = parsedData.companyUniqueName ?? companyUniqueName;
+        accountUniqueName = parsedData.account?.uniqueName ?? accountUniqueName;
       }
     }
 

--- a/src/app/[company]/[country]/login/page.tsx
+++ b/src/app/[company]/[country]/login/page.tsx
@@ -117,6 +117,7 @@ export default function LoginPage() {
     script.onload = () => {
       (window as any).initVerification?.({
         referenceId,
+        theme: "light",
         success: () => {
           console.log("Login initialized successfully");
         },

--- a/src/app/[company]/[country]/login/page.tsx
+++ b/src/app/[company]/[country]/login/page.tsx
@@ -8,51 +8,6 @@ import { getSessionCookie } from "@/utils/cookies";
 import { sessionManager } from "@/utils/sessionManager";
 import { useAppConfig } from "@/hooks/useAppConfig";
 
-function getActiveSession(
-  currentCompany: string,
-  currentCountry: string
-): { slug: string; country: string } | null {
-  // Check if this exact company has a session — handled separately
-  if (getSessionCookie(currentCompany)) return null;
-
-  // Primary: check localStorage userData (written by setupUserSession)
-  try {
-    const rawUserData = localStorage.getItem("userData");
-    if (rawUserData) {
-      const userData = JSON.parse(rawUserData);
-      const activeSlug = userData?.company;
-      const activeCountry = userData?.country;
-      if (activeSlug && activeCountry && activeSlug !== currentCompany) {
-        if (getSessionCookie(activeSlug)) {
-          return { slug: activeSlug, country: activeCountry };
-        }
-      }
-    }
-  } catch {
-    // ignore
-  }
-
-  // Fallback: scan all cookies for any "*-session" cookie
-  // Handles sessions created before userData stored company/country fields
-  try {
-    const cookies = document.cookie.split(";");
-    for (const cookie of cookies) {
-      const [name] = cookie.trim().split("=");
-      if (name && name.endsWith("-session")) {
-        const slug = name.slice(0, -"-session".length);
-        if (slug && slug !== currentCompany) {
-          // Use currentCountry as the redirect country — same portal
-          return { slug, country: currentCountry };
-        }
-      }
-    }
-  } catch {
-    // ignore
-  }
-
-  return null;
-}
-
 export default function LoginPage() {
   const params = useParams();
   const router = useRouter();
@@ -62,13 +17,9 @@ export default function LoginPage() {
   const company = params?.company as string;
   const country = params?.country as string;
 
-  // Detect redirect conditions synchronously so the auth script is never loaded
-  // when we are about to navigate away.
   const [isRedirecting, setIsRedirecting] = useState(() => {
     if (typeof window === "undefined" || !company || !country) return false;
-    if (getSessionCookie(company)) return true;
-    const other = getActiveSession(company, country);
-    return other !== null;
+    return !!getSessionCookie(company);
   });
 
   useEffect(() => {
@@ -89,24 +40,14 @@ export default function LoginPage() {
   useEffect(() => {
     if (!company || !country) return;
 
-    // If this company already has a session, go to welcome
     const sessionId = getSessionCookie(company);
     if (sessionId) {
       setIsRedirecting(true);
       router.push(`/${company}/${country}/welcome`);
-      return;
-    }
-
-    // If a DIFFERENT company is already logged in, redirect to that company instead
-    const other = getActiveSession(company, country);
-    if (other) {
-      setIsRedirecting(true);
-      router.replace(`/${other.slug}/${other.country}/welcome`);
     }
   }, [company, country, router]);
 
   useEffect(() => {
-    // Never load the auth widget if we are navigating away
     if (isRedirecting || !referenceId) return;
 
     const script = document.createElement("script");

--- a/src/app/[company]/[country]/payment/page.tsx
+++ b/src/app/[company]/[country]/payment/page.tsx
@@ -52,6 +52,7 @@ export default function PaymentsPage() {
 
   useEffect(() => {
     const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+      companyName,
       companyUniqueNameFromRedux,
       accountUniqueNameFromRedux
     );
@@ -81,6 +82,7 @@ export default function PaymentsPage() {
 
   const handlePaymentClick = (voucherUniqueName: string) => {
     const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames(
+      companyName,
       companyUniqueNameFromRedux,
       accountUniqueNameFromRedux
     );

--- a/src/app/[company]/[country]/payment/preview/page.tsx
+++ b/src/app/[company]/[country]/payment/preview/page.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/contexts/ToastContext";
 import { getSessionCookie } from "@/utils/cookies";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { DEFAULT_CONFIG } from "@/config/default";
+import { getCompanyAndAccountNames } from "@/utils/getUserDataFromStorage";
 
 function AuthHeader({ referenceId }: { referenceId: string }) {
   return (
@@ -65,33 +66,22 @@ export default function PaymentPreviewPage() {
   const hasSession =
     typeof window !== "undefined" && (!!sessionId || !!getSessionCookie(companyName));
 
-  const getCompanyAndAccountNames = () => {
-    let companyUniqueName = companyUniqueNameFromRedux;
-    let accountUniqueName = accountUniqueNameFromRedux;
-
-    if (!companyUniqueName || !accountUniqueName) {
-      if (typeof window !== "undefined") {
-        const userData = localStorage.getItem("userData");
-        if (userData) {
-          try {
-            const parsedData = JSON.parse(userData);
-            companyUniqueName = companyUniqueName || parsedData.companyUniqueName;
-            accountUniqueName = accountUniqueName || parsedData.account?.uniqueName;
-          } catch (e) {
-            console.error("Error parsing userData:", e);
-          }
-        }
-      }
-    }
-
-    if (!companyUniqueName) companyUniqueName = companyUniqueNameFromUrl;
-    if (!accountUniqueName) accountUniqueName = accountUniqueNameFromUrl;
-
-    return { companyUniqueName, accountUniqueName };
+  const resolveCompanyAndAccount = () => {
+    const fromStorage = getCompanyAndAccountNames(
+      companyName,
+      companyUniqueNameFromRedux,
+      accountUniqueNameFromRedux
+    );
+    return {
+      companyUniqueName:
+        fromStorage.companyUniqueName || companyUniqueNameFromUrl || undefined,
+      accountUniqueName:
+        fromStorage.accountUniqueName || accountUniqueNameFromUrl || undefined,
+    };
   };
 
   useEffect(() => {
-    const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames();
+    const { companyUniqueName, accountUniqueName } = resolveCompanyAndAccount();
     if (!companyUniqueName || !accountUniqueName) {
       setIsLoading(false);
       return;
@@ -173,7 +163,7 @@ export default function PaymentPreviewPage() {
   };
 
   const handleDownload = async () => {
-    const { companyUniqueName, accountUniqueName } = getCompanyAndAccountNames();
+    const { companyUniqueName, accountUniqueName } = resolveCompanyAndAccount();
     if (!companyUniqueName || !accountUniqueName) return;
 
     try {

--- a/src/app/[company]/[country]/payment/preview/page.tsx
+++ b/src/app/[company]/[country]/payment/preview/page.tsx
@@ -116,6 +116,7 @@ export default function PaymentPreviewPage() {
         if (!el) return;
         (window as unknown as { initVerification?: (opts: unknown) => void }).initVerification?.({
           referenceId,
+          theme: "light",
           success: () => {},
           failure: (err: unknown) => console.error("[PaymentPreview Auth] Login failed:", err),
         });

--- a/src/app/[company]/[country]/welcome/page.tsx
+++ b/src/app/[company]/[country]/welcome/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/store/slices/companySlice";
 import { useParams, usePathname } from "next/navigation";
 import { useEffect } from "react";
+import { getUserDataFromStorage } from "@/utils/getUserDataFromStorage";
 import { SortOrder } from "@/constants/sort";
 import { SidebarToggleButton } from "@/components/SidebarToggleButton";
 import { SwitchAccountButton } from "@/components/SwitchAccountButton";
@@ -33,15 +34,10 @@ export default function WelcomePage() {
     let accountUniqueName = accountUniqueNameFromRedux;
 
     if (!companyUniqueName && typeof window !== "undefined") {
-      const userData = localStorage.getItem("userData");
-      if (userData) {
-        try {
-          const parsedData = JSON.parse(userData);
-          companyUniqueName = parsedData.companyUniqueName;
-          accountUniqueName = parsedData.account?.uniqueName;
-        } catch (e) {
-          console.error("Error parsing userData:", e);
-        }
+      const parsedData = getUserDataFromStorage(companyName);
+      if (parsedData) {
+        companyUniqueName = parsedData.companyUniqueName ?? companyUniqueName;
+        accountUniqueName = parsedData.account?.uniqueName ?? accountUniqueName;
       }
     }
 

--- a/src/components/PayNow.tsx
+++ b/src/components/PayNow.tsx
@@ -25,7 +25,10 @@ import {
   InvoicePayVoucherDetailsResponse,
 } from "@/utils/payment";
 import { formatDateToAPI } from "@/utils/dateUtils";
-import { getCompanyAndAccountNames as getStorageNames } from "@/utils/getUserDataFromStorage";
+import {
+  getCompanyAndAccountNames as getStorageNames,
+  getUserDataFromStorage,
+} from "@/utils/getUserDataFromStorage";
 import { logger } from "@/utils/logger";
 import { useToast } from "@/contexts/ToastContext";
 import { ApiResponseStatus } from "@/utils/proxy/types";
@@ -111,7 +114,10 @@ export function PayNow({
     if (companyUniqueNameProp && accountUniqueNameProp) {
       return { companyUniqueName: companyUniqueNameProp, accountUniqueName: accountUniqueNameProp };
     }
-    return getStorageNames(companyUniqueNameFromRedux, accountUniqueNameFromRedux);
+    if (!companyName) {
+      return { companyUniqueName: undefined, accountUniqueName: undefined };
+    }
+    return getStorageNames(companyName, companyUniqueNameFromRedux, accountUniqueNameFromRedux);
   };
 
   useEffect(() => {
@@ -256,14 +262,13 @@ export function PayNow({
     }
 
     if (method === PAYMENT_METHODS_ENUM.PAYU) {
-      const userData = localStorage.getItem("userData");
       let hasDetails = false;
 
-      if (userData) {
+      if (companyName) {
         try {
-          const parsed = JSON.parse(userData);
+          const parsed = getUserDataFromStorage(companyName);
           if (
-            parsed.portalDetails?.name &&
+            parsed?.portalDetails?.name &&
             parsed.portalDetails?.email &&
             parsed.portalDetails?.contactNo
           ) {

--- a/src/components/SwitchAccountButton.tsx
+++ b/src/components/SwitchAccountButton.tsx
@@ -15,6 +15,8 @@ import { TIMING } from "@/constants/timing";
 import type { Account } from "@/types/auth";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import { mergeClassNames } from "@/lib/utils";
+import { getUserDataFromStorage, getUserEmailFromStorage } from "@/utils/getUserDataFromStorage";
+import { useAppConfig } from "@/hooks/useAppConfig";
 
 // Module-level cache: keyed by company slug, persists across page navigations
 const accountsCache: Record<string, Account[]> = {};
@@ -23,6 +25,7 @@ export function SwitchAccountButton() {
   const params = useParams();
   const router = useRouter();
   const dispatch = useAppDispatch();
+  const { switchAccountAuthErrorMessage } = useAppConfig();
   const company = params?.company as string;
   const country = params?.country as string;
   const currentAccountUniqueName = useAppSelector(selectAccountUniqueName(company));
@@ -64,11 +67,11 @@ export function SwitchAccountButton() {
     setError(null);
 
     try {
-      const email = localStorage.getItem("userEmail");
+      const email = getUserEmailFromStorage(company);
       const proxyToken = localStorage.getItem("proxy_auth_token");
 
       if (!email || !proxyToken) {
-        setError("Authentication data not found. Please log in again.");
+        setError(switchAccountAuthErrorMessage);
         setFetchingAccounts(false);
         return;
       }
@@ -117,10 +120,10 @@ export function SwitchAccountButton() {
 
     try {
       const proxyToken = localStorage.getItem("proxy_auth_token");
-      const email = localStorage.getItem("userEmail");
+      const email = getUserEmailFromStorage(company);
 
       if (!proxyToken || !email) {
-        setError("Authentication data not found. Please log in again.");
+        setError(switchAccountAuthErrorMessage);
         setLoading(false);
         isProcessing.current = false;
         return;
@@ -221,12 +224,12 @@ export function SwitchAccountButton() {
               <div className="space-y-0">
                 {accounts.map((account, index) => {
                   const isLastAccount = index === accounts.length - 1;
+                  const storedAccount =
+                    typeof window !== "undefined" ? getUserDataFromStorage(company) : null;
                   const isCurrentAccount =
                     account.account.uniqueName === currentAccountUniqueName ||
                     (!currentAccountUniqueName &&
-                      typeof window !== "undefined" &&
-                      account.account.uniqueName ===
-                      JSON.parse(localStorage.getItem("userData") || "{}")?.account?.uniqueName);
+                      account.account.uniqueName === storedAccount?.account?.uniqueName);
                   return (
                     <div key={index} className="group/acct-item relative w-full">
                       <span

--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -28,6 +28,10 @@ export interface GiddhWhiteLabel {
   brandName?: string;
 }
 
+export interface PortalMessagesConfig {
+  switchAccountAuthError?: string;
+}
+
 export interface WhiteLabelConfig {
   proxyApiUrl?: string;
   proxyApiUrlUk?: string;
@@ -36,6 +40,7 @@ export interface WhiteLabelConfig {
   proxyUrl?: string;
   websiteDomain?: string;
   giddhWhiteLabel?: GiddhWhiteLabel;
+  portalMessages?: PortalMessagesConfig;
 }
 
 export interface AppConfig {
@@ -49,7 +54,11 @@ export interface AppConfig {
   WEBSITE_DOMAIN: string;
   BRAND_NAME: string;
   LOGOS: LogoConfig;
+  SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE: string;
 }
+
+export const DEFAULT_SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE =
+  "Authentication data not found. Please log in again.";
 
 const PROD_CONFIG: AppConfig = {
   REFERENCE_ID: "117230e170290843965805217bfd25",
@@ -61,6 +70,7 @@ const PROD_CONFIG: AppConfig = {
   PAYPAL_URL: "https://www.paypal.com/cgi-bin/webscr",
   WEBSITE_DOMAIN: "https://giddh.com",
   BRAND_NAME: "Giddh",
+  SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE: DEFAULT_SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE,
   LOGOS: {
     primary: "/icons/giddh_text_icon.svg",
     light: "giddh-logo-dark.png",
@@ -80,6 +90,7 @@ const NON_PROD_CONFIG: AppConfig = {
   PAYPAL_URL: "https://www.sandbox.paypal.com/cgi-bin/webscr",
   WEBSITE_DOMAIN: "https://web.giddh.com",
   BRAND_NAME: "Giddh",
+  SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE: DEFAULT_SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE,
   LOGOS: {
     primary: "/icons/giddh_text_icon.svg",
     light: "giddh-logo-dark.png",
@@ -103,6 +114,8 @@ export function mergeWhiteLabelConfig(whiteLabel: WhiteLabelConfig | null): AppC
 
   const giddhWhiteLabel = whiteLabel.giddhWhiteLabel;
 
+  const apiSwitchAccountMsg = whiteLabel.portalMessages?.switchAccountAuthError?.trim();
+
   return {
     ...DEFAULT_CONFIG,
     PROXY_URL: whiteLabel.proxyUrl || DEFAULT_CONFIG.PROXY_URL,
@@ -114,6 +127,8 @@ export function mergeWhiteLabelConfig(whiteLabel: WhiteLabelConfig | null): AppC
     GIDDH_API_URL: giddhWhiteLabel?.apiDomain || DEFAULT_CONFIG.GIDDH_API_URL,
     BRAND_NAME: giddhWhiteLabel?.brandName || DEFAULT_CONFIG.BRAND_NAME,
     LOGOS: giddhWhiteLabel?.logos || DEFAULT_CONFIG.LOGOS,
+    SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE:
+      apiSwitchAccountMsg || DEFAULT_CONFIG.SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE,
   };
 }
 

--- a/src/hooks/useAppConfig.ts
+++ b/src/hooks/useAppConfig.ts
@@ -14,5 +14,6 @@ export function useAppConfig() {
     paypalUrl: config.PAYPAL_URL,
     referenceIdUk: config.REFERENCE_ID_UK,
     apiUrlUk: config.API_URL_UK,
+    switchAccountAuthErrorMessage: config.SWITCH_ACCOUNT_AUTH_ERROR_MESSAGE,
   };
 }

--- a/src/utils/accountStatement.ts
+++ b/src/utils/accountStatement.ts
@@ -116,10 +116,6 @@ export async function downloadAccountStatement(
   return response.data;
 }
 
-export function formatCurrency(amount: number, currencySymbol: string = "₹"): string {
-  return `${currencySymbol}${Math.abs(amount).toLocaleString("en-IN")}`;
-}
-
 /** Format date string for display (dd-MM-yyyy). Re-exported from dateUtils. */
 export const formatDate = formatDateDisplay;
 

--- a/src/utils/auth/setupUserSession.ts
+++ b/src/utils/auth/setupUserSession.ts
@@ -1,4 +1,5 @@
 import { setSessionCookie } from "@/utils/cookies";
+import { userDataStorageKey, userEmailStorageKey } from "@/utils/getUserDataFromStorage";
 import { setUserData, setAccount } from "@/store/slices/companySlice";
 import type { Account, UserData } from "@/types/auth";
 import type { AppDispatch } from "@/store/store";
@@ -47,9 +48,9 @@ export async function setupUserSession({
     })
   );
 
-  localStorage.setItem("userEmail", email);
+  localStorage.setItem(userEmailStorageKey(company), email);
   localStorage.setItem(
-    "userData",
+    userDataStorageKey(company),
     JSON.stringify({
       ...fullUserData,
       companyUniqueName,
@@ -57,4 +58,7 @@ export async function setupUserSession({
       country,
     })
   );
+
+  localStorage.removeItem("userData");
+  localStorage.removeItem("userEmail");
 }

--- a/src/utils/getUserDataFromStorage.ts
+++ b/src/utils/getUserDataFromStorage.ts
@@ -1,6 +1,19 @@
 import { logger } from "./logger";
 
+const LEGACY_USER_DATA_KEY = "userData";
+const LEGACY_USER_EMAIL_KEY = "userEmail";
+
+export function userDataStorageKey(companySlug: string): string {
+  return `userData:${companySlug}`;
+}
+
+export function userEmailStorageKey(companySlug: string): string {
+  return `userEmail:${companySlug}`;
+}
+
 interface StoredUserData {
+  company?: string;
+  country?: string;
   companyUniqueName?: string;
   account?: {
     uniqueName: string;
@@ -8,21 +21,47 @@ interface StoredUserData {
   };
   email?: string;
   vendorContactUniqueName?: string;
+  portalDetails?: {
+    name?: string;
+    email?: string;
+    contactNo?: string;
+  };
 }
 
-export function getUserDataFromStorage(): StoredUserData | null {
-  if (typeof window === "undefined") return null;
+function readLegacyUserDataForCompany(companySlug: string): StoredUserData | null {
+  try {
+    const legacy = localStorage.getItem(LEGACY_USER_DATA_KEY);
+    if (!legacy) return null;
+    const parsed = JSON.parse(legacy) as StoredUserData;
+    if (parsed?.company === companySlug) return parsed;
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export function getUserDataFromStorage(companySlug: string): StoredUserData | null {
+  if (typeof window === "undefined" || !companySlug) return null;
 
   try {
-    const userData = localStorage.getItem("userData");
-    return userData ? JSON.parse(userData) : null;
+    const namespaced = localStorage.getItem(userDataStorageKey(companySlug));
+    if (namespaced) return JSON.parse(namespaced) as StoredUserData;
+    return readLegacyUserDataForCompany(companySlug);
   } catch (error) {
     logger.error("Error parsing userData from localStorage", error);
     return null;
   }
 }
 
+export function getUserEmailFromStorage(companySlug: string): string | null {
+  if (typeof window === "undefined" || !companySlug) return null;
+  const scoped = localStorage.getItem(userEmailStorageKey(companySlug));
+  if (scoped) return scoped;
+  return localStorage.getItem(LEGACY_USER_EMAIL_KEY);
+}
+
 export function getCompanyAndAccountNames(
+  companySlug: string,
   companyUniqueNameFromRedux?: string | null,
   accountUniqueNameFromRedux?: string | null
 ): {
@@ -33,7 +72,7 @@ export function getCompanyAndAccountNames(
   let accountUniqueName = accountUniqueNameFromRedux || undefined;
 
   if (!companyUniqueName || !accountUniqueName) {
-    const userData = getUserDataFromStorage();
+    const userData = getUserDataFromStorage(companySlug);
     if (userData) {
       companyUniqueName = companyUniqueName || userData.companyUniqueName;
       accountUniqueName = accountUniqueName || userData.account?.uniqueName;

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -1,13 +1,12 @@
 import { deleteSessionCookie } from "./cookies";
+import { userDataStorageKey, userEmailStorageKey } from "./getUserDataFromStorage";
 
-/** Keys cleared on logout so session-expired modal and re-login flow behave correctly. */
-const AUTH_STORAGE_KEYS = ["proxy_auth_token", "userEmail", "userData"] as const;
-
-export const logoutCompany = (companyUniqueName: string) => {
-  if (companyUniqueName) {
-    deleteSessionCookie(companyUniqueName);
+export const logoutCompany = (companySlug: string) => {
+  if (companySlug) {
+    deleteSessionCookie(companySlug);
   }
-  if (typeof window !== "undefined") {
-    AUTH_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
+  if (typeof window !== "undefined" && companySlug) {
+    localStorage.removeItem(userDataStorageKey(companySlug));
+    localStorage.removeItem(userEmailStorageKey(companySlug));
   }
 };


### PR DESCRIPTION
1. Per-company browser storage: userData and userEmail are saved under keys that include the company from the URL, so multiple companies in different tabs don’t overwrite each other’s data.
2. Cleanup after login: After writing the new namespaced keys, the old global userData / userEmail entries are removed so you’re not stuck on stale shared data.
3. Shared helpers: One place reads and parses stored user info (getUserDataFromStorage, getCompanyAndAccountNames, etc.), so individual pages don’t duplicate localStorage logic.
4. Logout: Clearing a session removes that company’s stored user/email only, matching the new per-company keys.
5. Account statement: Money amounts use the same app-wide currency formatter and full currency object, not a separate local formatter.
6. Switch account: The “missing auth, log in again” style message can come from white-label config, with a default if the API doesn’t send one.
7. Login behavior: You’re only sent straight to welcome if this company already has a session; the app no longer redirects you to a different company’s portal just because that session exists.